### PR TITLE
Use namespaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .mypy_cache**
 .vscode**
 config.json
+__pycache__

--- a/main.py
+++ b/main.py
@@ -225,11 +225,11 @@ class Adapter:
         """
         new_topic_to_type = {}  # type: Dict[str, Any]
 
-        for node_name in self.node.get_node_names():
+        for node_name, node_namespace in self.node.get_node_names_and_namespaces():
             for (
                 topic_name,
                 topic_types,
-            ) in self.node.get_publisher_names_and_types_by_node(node_name, ""):
+            ) in self.node.get_publisher_names_and_types_by_node(node_name, node_namespace):
                 if topic_name not in self.get_configured_topics():
                     continue
                 if len(topic_types) == 0:


### PR DESCRIPTION
We had some problems where it didn't think topics existed because they had namespaces. This fixed the issue and should work even if the namespace is blank.

I also added `__pycache__` to `.gitignore` to keep those artifacts from getting onto the repo.