### PR TITLE
make exec depends so they don't get included in bloom build depends

### DIFF
--- a/formant_ros2_adapter/package.xml
+++ b/formant_ros2_adapter/package.xml
@@ -11,8 +11,8 @@
   <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <depend>rclpy</depend>
-  <depend>python-lzf-pip</depend>
-  <depend>python3-numpy</depend>
+  <exec_depend>python-lzf-pip</exec_depend>
+  <exec_depend>python3-numpy</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
While experimenting with bloom, I noticed that if pip dependencies are included as build dependencies, it fails. This explicitly makes them exec dependencies.