### PR TITLE
remove python package install

### DIFF
--- a/formant_ros2_adapter/CMakeLists.txt
+++ b/formant_ros2_adapter/CMakeLists.txt
@@ -13,8 +13,6 @@ find_package(rclpy REQUIRED)
 install(DIRECTORY scripts/converters DESTINATION lib/${PROJECT_NAME})
 install(DIRECTORY scripts/message_utils DESTINATION lib/${PROJECT_NAME})
 
-ament_python_install_package(scripts)
-
 execute_process (
     COMMAND bash -c "python3 -m pip install -r ${CMAKE_CURRENT_SOURCE_DIR}/../requirements.txt"
 )


### PR DESCRIPTION
Remove python package install, since it is:
- not used
- collides with `gazebo_ros` (because their package is also called "scripts": https://github.com/ros-simulation/gazebo_ros_pkgs/pull/1428)

This doesn't affect the main script being installed as a program.