### PR TITLE
Update rosdep

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ Choose where you would like to have your workspace if you do not already have on
 
 `git clone <URL for this Repo>`
 
+`cd ros2-adapter`
+
+`python3 -m pip install -r requirements.txt`
+
 `cd ../..`
 
 `source /opt/ros/<Desired Distro>/setup.bash` (this adapter is meant to work with any ROS2 distribution eloquent+)

--- a/formant_ros2_adapter/CMakeLists.txt
+++ b/formant_ros2_adapter/CMakeLists.txt
@@ -15,10 +15,6 @@ install(DIRECTORY scripts/message_utils DESTINATION lib/${PROJECT_NAME})
 
 ament_python_install_package(scripts)
 
-execute_process (
-    COMMAND bash -c "python3 -m pip install -r ${CMAKE_CURRENT_SOURCE_DIR}/../requirements.txt"
-)
-
 #Install scripts
 install(PROGRAMS
   scripts/main.py

--- a/formant_ros2_adapter/package.xml
+++ b/formant_ros2_adapter/package.xml
@@ -13,6 +13,8 @@
   <depend>rclpy</depend>
   <depend>python-lzf-pip</depend>
   <depend>python3-numpy</depend>
+  <exec_depend>python3-formant-pip</exec_depend>
+  <exec_depend>python3-opencv</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
With the [addition of `formant` to rosdep](https://github.com/ros/rosdistro/pull/34666) all of the dependencies can now be captured in the `package.xml`. This means you _could_ install dependencies with `rosdep install --from-paths .`, but `numpy` and `opencv-python` would be maybe too old of versions. This is one step closer to making this package compliant for standard ROS packaging.

The pip install of dependencies is removed from the CMake, since installing dependencies shouldn't really go there. The best example of that is when a package is built on one platform and executed on another, then the dependency install doesn't transfer.