### PR TITLE
Update CMakeLists.txt to include all runtime scripts

### DIFF
--- a/formant_ros2_adapter/CMakeLists.txt
+++ b/formant_ros2_adapter/CMakeLists.txt
@@ -10,8 +10,7 @@ find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 find_package(rclpy REQUIRED)
 
-install(DIRECTORY scripts/converters DESTINATION lib/${PROJECT_NAME})
-install(DIRECTORY scripts/message_utils DESTINATION lib/${PROJECT_NAME})
+install(DIRECTORY scripts/ DESTINATION lib/${PROJECT_NAME} PATTERN "config_examples" EXCLUDE)
 
 execute_process (
     COMMAND bash -c "python3 -m pip install -r ${CMAKE_CURRENT_SOURCE_DIR}/../requirements.txt"


### PR DESCRIPTION
When "building" this as a submodule in cmake I saw the following error:
![image](https://github.com/FormantIO/ros2-adapter/assets/5544243/13a6c3f0-9e5b-4e2b-a71b-badde7d43db3)

It seems it would want all script subdirectories so added them except for config_examples.
It looks like this:
![image](https://github.com/FormantIO/ros2-adapter/assets/5544243/3b83799e-92a8-4475-914c-467b3e817a37)
