### PR TITLE
Fix errors when instantiating numeric set subscriber

### DIFF
--- a/formant_ros2_adapter/scripts/components/subscriber/numeric_set_subscriber_coodinator.py
+++ b/formant_ros2_adapter/scripts/components/subscriber/numeric_set_subscriber_coodinator.py
@@ -84,11 +84,11 @@ class NumericSetSubscriberCoordinator:
                 subscriber.qos_profile, qos_profile_system_default
             )
 
-            new_sub = self.ros2_node.create_subscription(
+            new_sub = self._node.create_subscription(
                 get_ros2_type_from_string(ros2_type),
                 topic,
-                lambda msg, stream=formant_stream, config=numeric_set_config, subscriber_config=subscriber: self._handle_message(
-                    msg, stream, config, subscriber_config
+                lambda msg, config=numeric_set_config, subscriber_config=subscriber: self._handle_message(
+                    msg, config, subscriber_config
                 ),
                 qos_profile=qos_profile,
             )
@@ -100,12 +100,9 @@ class NumericSetSubscriberCoordinator:
         subscriber_config: NumericSetSubscriberConfig,
     ):
         with self._config_lock:
-            self._logger.info("Handling message")
             formant_stream = numeric_set_config.formant_stream
             path = subscriber_config.message_path
             if path:
-                path = subscriber_config["ros2_message_path"]
-
                 try:
                     msg = get_message_path_value(msg, path)
                     msg_type = type(msg)


### PR DESCRIPTION
When creating numeric sets there are some incorrect member variable accesses, this PR fixes them. Tested by successfully creating subscribers and streaming to Formant.io.

There was also an info message printing for every subscriber callback which is removed.

_Relevant error pre-fix_
![ros2-adapter-no-ros2_node](https://github.com/FormantIO/ros2-adapter/assets/100799890/a79e29a7-c819-4b9c-861e-a0fd3ef091c5)
