### PR TITLE
allow ROS_DOMAIN_ID to be set

### DIFF
--- a/formant_ros2_adapter/scripts/main.py
+++ b/formant_ros2_adapter/scripts/main.py
@@ -9,6 +9,8 @@ from utils.logger import get_logger
 import os
 
 ROS2_DOMAIN_ID = os.environ.get("ROS_DOMAIN_ID", None)
+if ROS2_DOMAIN_ID:
+    ROS2_DOMAIN_ID=int(ROS2_DOMAIN_ID)
 
 FCLIENT_WAIT = 2
 


### PR DESCRIPTION
Environ.get returns string and ros2 wants int.

Traceback (most recent call last):
  File "/app/formant_ros2_adapter/scripts/main.py", line 19, in <module>
    rclpy.init(domain_id=ROS2_DOMAIN_ID)
  File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/__init__.py", line 89, in init
    return context.init(args, domain_id=domain_id)
  File "/opt/ros/humble/local/lib/python3.10/dist-packages/rclpy/context.py", line 64, in init
    if domain_id is not None and domain_id < 0:
TypeError: '<' not supported between instances of 'str' and 'int'