### PR TITLE
allow localization_config.py to parse the config_example_full.json ev…

### DIFF
--- a/formant_ros2_adapter/scripts/configuration/localization_config.py
+++ b/formant_ros2_adapter/scripts/configuration/localization_config.py
@@ -39,4 +39,7 @@ class LocalizationConfig:
 
 class PointCloudSubscriberConfig:
     def __init__(self, config: Dict):
-        self.topic: str = get_value(config, "ros2_topic", required=True)
+        if isinstance(config, dict):
+            self.topic: str = get_value(config, "ros2_topic", required=True)
+        elif isinstance(config, str):
+            self.topic: str = config


### PR DESCRIPTION
…en though it does not match schema

When pulling latest adapter started getting this error. Realized it is because my config matches the old way / the example and not the schema & current parsing.

ERROR:formant_ros2_adapter:Traceback (most recent call last): File "/app/formant_ros2_adapter/scripts/ros2_adapter.py", line 54, in setup_with_config self.config = ConfigSchema(config["ros2_adapter_configuration"]) File "/app/formant_ros2_adapter/scripts/configuration/config_schema.py", line 23, in __init__ self.localization: Optional[LocalizationConfig] = get_value( File "/app/formant_ros2_adapter/scripts/configuration/get_value.py", line 15, in get_value return cls(data)
File "/app/formant_ros2_adapter/scripts/configuration/localization_config.py", line 20, in __init__ ] = get_value(
File "/app/formant_ros2_adapter/scripts/configuration/get_value.py", line 13, in get_value return [cls(item) for item in data]
File "/app/formant_ros2_adapter/scripts/configuration/get_value.py", line 13, in <listcomp> return [cls(item) for item in data]
File "/app/formant_ros2_adapter/scripts/configuration/localization_config.py", line 43, in __init__ self.topic: str = get_value(config, "ros2_topic", required=True) File "/app/formant_ros2_adapter/scripts/configuration/get_value.py", line 3, in get_value data = config.get(key, None)
AttributeError: 'str' object has no attribute 'get'