### PR TITLE
Fixes exception when ingesting ROS numeric type data

### DIFF
--- a/formant_ros2_adapter/scripts/components/subscriber/ingester.py
+++ b/formant_ros2_adapter/scripts/components/subscriber/ingester.py
@@ -63,7 +63,7 @@ class Ingester:
         msg_timestamp: int,
         tags: Dict,
     ):
-        self._logger.info("Ingesting message " + str(msg) + " to " + formant_stream)
+        self._logger.debug("Ingesting message " + str(msg) + " to " + formant_stream)
         # Handle the message based on its type
         try:
             if msg_type in [str, String, Char]:

--- a/formant_ros2_adapter/scripts/components/subscriber/ingester.py
+++ b/formant_ros2_adapter/scripts/components/subscriber/ingester.py
@@ -63,27 +63,27 @@ class Ingester:
         msg_timestamp: int,
         tags: Dict,
     ):
-
+        self._logger.info("Ingesting message " + str(msg) + " to " + formant_stream)
         # Handle the message based on its type
         try:
             if msg_type in [str, String, Char]:
                 if hasattr(msg, "data"):
-                    msg = msg.data
+                    ingested_data = msg.data
 
                 self._fclient.post_text(
                     formant_stream,
-                    str(msg),
+                    str(ingested_data),
                     tags=tags,
                     timestamp=msg_timestamp,
                 )
 
             elif msg_type in [Bool, bool]:
                 if hasattr(msg, "data"):
-                    msg = msg.data
+                    ingested_data = msg.data
 
                 self._fclient.post_bitset(
                     formant_stream,
-                    {topic: msg},
+                    {topic: ingested_data},
                     tags=tags,
                     timestamp=msg_timestamp,
                 )
@@ -102,12 +102,13 @@ class Ingester:
                 UInt32,
                 UInt64,
             ]:
+
                 if hasattr(msg, "data"):
-                    msg = msg.data
+                    ingested_data = msg.data
 
                 self._fclient.post_numeric(
                     formant_stream,
-                    msg,
+                    ingested_data,
                     tags=tags,
                     timestamp=msg_timestamp,
                 )

--- a/start.sh
+++ b/start.sh
@@ -4,7 +4,7 @@
 source /opt/ros/*/setup.bash
 # Optional ROS environment variables
 #export ROS_DOMAIN_ID=1
-#export ROS_LOCALHOST_ONLY=1
+#export ROS_LOCALHOST_ONLY=1 #un-comment for local only ingestion
 #export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
 
 if [ -z ${FORMANT_ROS2_WS+x} ]; then


### PR DESCRIPTION
Fixes `ERROR:formant_ros2_adapter:Could not ingest ros2.counter: 'int' object has no attribute 'data`
